### PR TITLE
fix: move the file argument after flag in init command

### DIFF
--- a/docs/validators/setup/cli.md
+++ b/docs/validators/setup/cli.md
@@ -59,14 +59,14 @@ To set up the origin state of the chain, initialize the genesis block. In your c
   <TabItem value="mainnet" label="Mainnet" default>
 
   ```bash
-  ronin init genesis/mainnet.json --datadir ~/roninchain/data
+  ronin init --datadir ~/roninchain/data genesis/mainnet.json
   ```
 
   </TabItem>
   <TabItem value="testnet" label="Testnet" default>
 
   ```bash
-  ronin init genesis/testnet.json --datadir ~/roninchain/data
+  ronin init --datadir ~/roninchain/data genesis/testnet.json
   ```
 
   </TabItem>


### PR DESCRIPTION
<!--
Thank you for contributing to the Ronin documentation! You must fill out the information before we can review this PR. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request for review.
-->

### Reason

Closes: N/A

<!-- If there's an existing issue for your change, link to it above.
If there's no existing issue, create one first to make it more likely that this update is accepted: https://github.com/axieinfinity/ronin-documentation/issues/new/choose. -->

### What's being changed

We've recently merged a PR to upgrade the cli package to version 2 in Ronin. This version requires the command argument must be after the flags. So this commit edits the init command to follow that rule.

<!-- Describe what you're changing. If available, include any code snippets, screenshots, or anything that could provide the most context.-->

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
