### PR TITLE
fix: add missing param GENERATE_BLS_PROOF

### DIFF
--- a/docs/validators/setup/mainnet/run-combined.md
+++ b/docs/validators/setup/mainnet/run-combined.md
@@ -90,6 +90,7 @@ For more information, see [Generate keys](../generate-keys.md).
          - ENABLE_FAST_FINALITY=${ENABLE_FAST_FINALITY}
          - ENABLE_FAST_FINALITY_SIGN=${ENABLE_FAST_FINALITY_SIGN}
          - BLS_SHOW_PRIVATE_KEY=${BLS_SHOW_PRIVATE_KEY}
+         - GENERATE_BLS_PROOF=${GENERATE_BLS_PROOF}
      db:
        image: postgres:14.3
        restart: always

--- a/docs/validators/setup/mainnet/run-validator.md
+++ b/docs/validators/setup/mainnet/run-validator.md
@@ -72,6 +72,7 @@ Generate a private key for your validator node. For more information, see [Gener
          - ENABLE_FAST_FINALITY=${ENABLE_FAST_FINALITY}
          - ENABLE_FAST_FINALITY_SIGN=${ENABLE_FAST_FINALITY_SIGN}
          - BLS_SHOW_PRIVATE_KEY=${BLS_SHOW_PRIVATE_KEY}
+         - GENERATE_BLS_PROOF=${GENERATE_BLS_PROOF}
    ```
 
    This compose file defines the `node` service that pulls a Ronin node image from the GitHub Container Registry.

--- a/docs/validators/setup/testnet/run-combined.md
+++ b/docs/validators/setup/testnet/run-combined.md
@@ -91,6 +91,7 @@ For more information, see [Generate keys](../generate-keys.md).
          - ENABLE_FAST_FINALITY=${ENABLE_FAST_FINALITY}
          - ENABLE_FAST_FINALITY_SIGN=${ENABLE_FAST_FINALITY_SIGN}
          - BLS_SHOW_PRIVATE_KEY=${BLS_SHOW_PRIVATE_KEY}
+         - GENERATE_BLS_PROOF=${GENERATE_BLS_PROOF}
      db:
        image: postgres:14.3
        restart: always


### PR DESCRIPTION
Right now, we only set in env without specifying this environment in docker-compose.yml