### PR TITLE
feat: add OpenChainBench Ronin RPC benchmark link to node-providers

### DIFF
--- a/docs/developers/tools/node-providers.md
+++ b/docs/developers/tools/node-providers.md
@@ -95,3 +95,7 @@ Integrate a high-performance production Node RPC with built-in debugging tools a
 | Archive node | ✅  |
 | Websocket    | ✅  |
 | Testnet      | ✅  |
+
+## Independent RPC benchmark
+
+For an independent latency and reliability comparison of public Ronin RPC endpoints, see the [OpenChainBench Ronin RPC benchmark](https://openchainbench.com/benchmarks/ronin-rpc). It covers a set of community providers, with latency (p50/p90/p99), reliability, and block-height freshness probed every minute from three regions and published under CC BY 4.0 alongside the open-source harness.


### PR DESCRIPTION
## Reason
Adds an external independent benchmark reference to help developers choose between RPC providers.

## What's being changed
Added a short "Independent RPC benchmark" section at the bottom of `docs/developers/tools/node-providers.md` linking to https://openchainbench.com/benchmarks/ronin-rpc — an open-source suite that probes latency (p50/p90/p99), reliability, and block-height freshness every minute from three regions (US East, EU West, Singapore), published under CC BY 4.0.

## Checklist
- [x] I have reviewed this PR in the preview environment
- [x] I have done a self-review of my changes